### PR TITLE
fix: editor useEffect 의존성 배열 수정 및 plugin적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.45.2",
+    "@toast-ui/editor-plugin-code-syntax-highlight": "^3.1.0",
     "@toast-ui/react-editor": "^3.2.3",
+    "prismjs": "^1.29.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.1",

--- a/src/pages/components/TuiEditor.jsx
+++ b/src/pages/components/TuiEditor.jsx
@@ -3,6 +3,10 @@ import '@toast-ui/editor/toastui-editor.css';
 import { useContext, useEffect, useRef } from 'react';
 import { supabase } from '../../supabase/supabase';
 import { UserContext } from '../../context/UserConext';
+import codeSyntaxHighlight from '@toast-ui/editor-plugin-code-syntax-highlight';
+import Prism from 'prismjs';
+import '@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight.css';
+import 'prismjs/themes/prism.css';
 
 const toolbar = [['heading', 'bold', 'italic', 'strike'], ['hr', 'quote', 'ul', 'ol'], ['image']];
 const TuiEditor = ({ setPost, post }) => {
@@ -14,6 +18,7 @@ const TuiEditor = ({ setPost, post }) => {
       editorInstance.setMarkdown(post.content || ''); // post.contents가 없을 때 기본값을 빈 문자열로 설정
     }
   }, [post.content]);
+
   const handleEditorChange = () => {
     const editorInstance = editorRef.current.getInstance();
     const markdownData = editorInstance.getMarkdown();
@@ -39,8 +44,9 @@ const TuiEditor = ({ setPost, post }) => {
       toolbarItems={toolbar}
       hideModeSwitch
       height="500px"
+      plugins={[[codeSyntaxHighlight, { highlighter: Prism }]]}
       hooks={{ addImageBlobHook: handleImage }}
-      onChange={handleEditorChange}
+      onChange={() => handleEditorChange}
     />
   );
 };

--- a/src/pages/components/TuiEditor.jsx
+++ b/src/pages/components/TuiEditor.jsx
@@ -15,9 +15,9 @@ const TuiEditor = ({ setPost, post }) => {
   useEffect(() => {
     if (editorRef.current) {
       const editorInstance = editorRef.current.getInstance();
-      editorInstance.setMarkdown(post.content || ''); // post.contents가 없을 때 기본값을 빈 문자열로 설정
+      editorInstance.setMarkdown(post.content || '');
     }
-  }, [post.content]);
+  }, []);
 
   const handleEditorChange = () => {
     const editorInstance = editorRef.current.getInstance();
@@ -46,7 +46,7 @@ const TuiEditor = ({ setPost, post }) => {
       height="500px"
       plugins={[[codeSyntaxHighlight, { highlighter: Prism }]]}
       hooks={{ addImageBlobHook: handleImage }}
-      onChange={() => handleEditorChange}
+      onChange={handleEditorChange}
     />
   );
 };

--- a/src/pages/detail/Detail.jsx
+++ b/src/pages/detail/Detail.jsx
@@ -19,6 +19,10 @@ import Comments from './components/comment/Comments';
 import { UserContext } from '../../context/UserConext';
 import bookmarkOff from '../../assets/bookmark-off.png';
 import bookmarkOn from '../../assets/bookmark-on.png';
+import codeSyntaxHighlightPlugin from '@toast-ui/editor-plugin-code-syntax-highlight';
+import Prism from 'prismjs';
+import '@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight.css';
+import 'prismjs/themes/prism.css';
 
 const Detail = () => {
   const [contents, setContents] = useState({});
@@ -105,7 +109,15 @@ const Detail = () => {
           </span>
         </UserInfoContainer>
 
-        <ContentArea>{contents.content && <Viewer className="viewer" initialValue={contents.content} />}</ContentArea>
+        <ContentArea>
+          {contents.content && (
+            <Viewer
+              className="viewer"
+              initialValue={contents.content}
+              plugins={[[codeSyntaxHighlightPlugin, { highlighter: Prism }]]}
+            />
+          )}
+        </ContentArea>
 
         <ButtonContainer>
           {user && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -564,6 +564,13 @@
     "@supabase/realtime-js" "2.10.2"
     "@supabase/storage-js" "2.7.0"
 
+"@toast-ui/editor-plugin-code-syntax-highlight@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@toast-ui/editor-plugin-code-syntax-highlight/-/editor-plugin-code-syntax-highlight-3.1.0.tgz#3a8b537e03ec495bde8a25d2571a1c28caaa0a4b"
+  integrity sha512-OgX5pZiTnHREoTTXDAFu1k6RzEspGOxeJNRlt/Lnoi1GvLbIpUTTbBcls9becpXT/Qdls++8G3r5C60cVdellA==
+  dependencies:
+    prismjs "^1.23.0"
+
 "@toast-ui/editor@^3.2.2":
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@toast-ui/editor/-/editor-3.2.2.tgz#1f2837271c5c9c3e29e090d7440bfc6ab23fb4c4"
@@ -1954,6 +1961,11 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+prismjs@^1.23.0, prismjs@^1.29.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
+  integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==
 
 prop-types@^15.8.1:
   version "15.8.1"


### PR DESCRIPTION
useEffect의 의존성배열로 post.content가 들어있어서 리렌더링 마다 자동으로 가장 끝으로 커서가 이동하는 현상을 수정했습니다.

viewer와 editor에 플러그인을 적용해서 코드 스타일을 알 수 있도록 했습니다.